### PR TITLE
Add new projects with live site support in expandable list

### DIFF
--- a/components/ProjectList.tsx
+++ b/components/ProjectList.tsx
@@ -8,10 +8,11 @@ interface Project {
   title: string
   description: string
   href?: string
+  liveSrc?: string
   imgSrc?: string
 }
 
-function ProjectRow({ title, description, href, imgSrc }: Project) {
+function ProjectRow({ title, description, href, liveSrc, imgSrc }: Project) {
   const [open, setOpen] = useState(false)
 
   return (
@@ -50,15 +51,26 @@ function ProjectRow({ title, description, href, imgSrc }: Project) {
             </div>
           )}
           <p className="prose max-w-none text-gray-500 dark:text-gray-400">{description}</p>
-          {href && (
-            <Link
-              href={href}
-              className="mt-3 inline-block text-base font-medium leading-6 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-              aria-label={`Link to ${title}`}
-            >
-              View project &rarr;
-            </Link>
-          )}
+          <div className="mt-3 flex flex-wrap gap-4">
+            {href && (
+              <Link
+                href={href}
+                className="text-base font-medium leading-6 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                aria-label={`GitHub repository for ${title}`}
+              >
+                View project &rarr;
+              </Link>
+            )}
+            {liveSrc && (
+              <Link
+                href={liveSrc}
+                className="text-base font-medium leading-6 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                aria-label={`Live site for ${title}`}
+              >
+                Live site &rarr;
+              </Link>
+            )}
+          </div>
         </div>
       )}
     </li>

--- a/data/projectsData.ts
+++ b/data/projectsData.ts
@@ -2,6 +2,7 @@ interface Project {
   title: string
   description: string
   href?: string
+  liveSrc?: string
   imgSrc?: string
 }
 
@@ -26,6 +27,23 @@ const projectsData: Project[] = [
   through a Next.js BFF proxy that holds the JWT in an httpOnly cookie, keeping the backend URL and credentials off the client
   entirely`,
     href: 'https://github.com/edtbl76/stud.io',
+  },
+  {
+    title: 'Weyland AI/Harness Engineering Lab',
+    description: `Weyland AI/Harness Engineering Lab is a self-hosted, multi-node AI platform for engineering and experimentation
+    with LLMs, vector databases, graph databases, and data pipelines. The stack spans local LLM inference, embedding generation,
+    workflow automation, and Kubernetes (K3s)-managed services.`,
+    href: 'https://github.com/edtbl76/weyland-lab',
+  },
+  {
+    title: 'MIDI Real Book',
+    description: `MIDI Real Book is a Progressive Web App (PWA) and ensemble reference database cataloging 141+ musical groups
+    across jazz, rock, fusion, soul, and classical eras. Each entry covers player profiles, historical timelines, gear, and key
+    recordings. Built with Eleventy 3.x and Nunjucks templating, deployed on Firebase Hosting via GitHub Actions CI/CD, with a
+    versioned service worker enabling full offline access after first visit. Python handles automated PWA icon generation using
+    Pillow and CairoSVG.`,
+    href: 'https://github.com/edtbl76/midi_real_book',
+    liveSrc: 'https://midi-real-book.web.app/',
   },
   {
     title: 'Algopedia',


### PR DESCRIPTION
This pull request introduces the following changes:

- Added two new projects: "Weyland AI" and "MIDI Real Book".
- Enabled live site links for the new projects in an expandable list format.

No additional changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now display optional live site links directly alongside their GitHub repository links in expanded detail views
  * Enhanced project detail panels with improved, flexible layout for displaying multiple related links simultaneously

* **Content Updates**
  * Added two new projects to the portfolio collection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->