### PR TITLE
fix(deps): override next's exact postcss pin to clear the last 3 alerts

### DIFF
--- a/docs/learned.md
+++ b/docs/learned.md
@@ -114,6 +114,27 @@ the only way to get the libvips fixes. Revisit once both widen their ranges. Ver
 working rather than assumed: sharp encodes, the build passes, and `/_next/image` returns a
 resized WebP.
 
+**`resolutions.postcss = ^8.5.18` exists for the same reason, one layer down.** `next`
+declares `"postcss": "8.4.31"` — an **exact pin**, not a range — so Dependabot bumping the
+top-level to 8.5.25 left a second, vulnerable copy nested under next. Three alerts survived
+five Dependabot PRs for exactly this reason. **Dependabot can only raise what your own
+manifest declares; it cannot override what a dependency pins internally.** That is what
+`resolutions` is for, and the tell is two entries for one package in `yarn.lock`:
+
+```
+"postcss@npm:8.4.31":   -> 8.4.31   vulnerable
+"postcss@npm:^8.4.47":  -> 8.5.25   patched
+```
+
+Safe here because the generated CSS is **byte-identical** before and after (72,209 bytes,
+same SHA) — worth re-checking that way if the range ever moves, since postcss is the whole
+CSS pipeline rather than a leaf dependency.
+
+**A lockfile can disagree with its own `package.json`.** After the Dependabot merges, main's
+`yarn.lock` had no `postcss@npm:^8.5.18` descriptor even though `package.json` declared that
+range, so `yarn install --immutable` failed — CI using that flag would have broken. Reconciled
+here. **`yarn install --immutable` is the cheap check for it.**
+
 **Optional follow-up:** `next.config.js` allows `picsum.photos` in `remotePatterns`, used
 only as a fallback in `layouts/PostBanner.tsx` — a layout no post selects, since none sets
 `layout:`. It remains a live third-party proxy target via `/_next/image`. Removing it would

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "packageManager": "yarn@3.6.1",
   "resolutions": {
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "postcss": "^8.5.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7378,15 +7378,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.6":
-  version: 3.3.15
-  resolution: "nanoid@npm:3.3.15"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 0f645685aefba48aae06acfb390be660041d91b4ec63d85544ed01b619c6d661c985170bfbcd29b7265b6c1c3369c631e5dcb2f34c34e2c0023108bc158531d1
-  languageName: node
-  linkType: hard
-
 "napi-postinstall@npm:^0.3.4":
   version: 0.3.4
   resolution: "napi-postinstall@npm:0.3.4"
@@ -7992,18 +7983,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
-  dependencies:
-    nanoid: ^3.3.6
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 1d8611341b073143ad90486fcdfeab49edd243377b1f51834dc4f6d028e82ce5190e4f11bb2633276864503654fb7cab28e67abdc0fbf9d1f88cad4a0ff0beea
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.47":
+"postcss@npm:^8.5.18":
   version: 8.5.25
   resolution: "postcss@npm:8.5.25"
   dependencies:
@@ -9273,7 +9253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 4eb0cd997cdf228bc253bcaff9340afeb706176e64868ecd20efbe6efea931465f43955612346d6b7318789e5265bdc419bc7669c1cebe3db0eb255f57efa76b
@@ -9631,6 +9611,7 @@ __metadata:
     lint-staged: ^13.0.0
     next: 15.5.21
     next-themes: ^0.3.0
+    postcss: ^8.5.18
     prettier: ^3.0.0
     prettier-plugin-tailwindcss: ^0.5.11
     react: 18.3.1


### PR DESCRIPTION
## What & why

Clears the last 3 Dependabot alerts, which survived five Dependabot PRs.

They persisted because **`next` declares `"postcss": "8.4.31"` — an exact pin, not a range.** Bumping the top-level to 8.5.25 (#87) patched the workspace and tailwind copies but could not touch the one nested under next, leaving two entries in `yarn.lock`:

```
"postcss@npm:8.4.31"   -> 8.4.31   vulnerable (< 8.5.10, <= 8.5.11, <= 8.5.17)
"postcss@npm:^8.4.47"  -> 8.5.25   patched
```

Dependabot can only raise what this manifest declares; it has no way to override what a dependency pins internally. `resolutions` is the only lever, and the repo already uses one for `sharp` for the same reason a layer up.

Also **reconciles `yarn.lock` with `package.json`**. After the Dependabot merges, main had no `postcss@npm:^8.5.18` descriptor despite `package.json` declaring that range, so `yarn install --immutable` failed — any CI step using that flag would have broken.

## How it was validated

```
yarn install --immutable  -> Done (was: "lockfile would have been modified", i.e. failing)
yarn test                 -> 61 tests, 61 pass, 0 fail
yarn validate:all         -> 33 files, 0 errors, 36 warnings
yarn lint                 -> No ESLint warnings or errors
yarn build                -> Compiled successfully, 45/45 static pages, RSS generated
```

- **`yarn why postcss`** confirms a single resolution reaching every consumer — both `next@15.5.21` instances, `tailwindcss@3.4.19`, and the workspace all get `8.5.25`.
- **The generated CSS is byte-identical** before and after: 72,209 bytes, matching SHA-256. This is the check that matters, because postcss is the entire CSS pipeline rather than a leaf dependency — a green build alone would not have proved the output unchanged.

## Notes

`resolutions` now holds two deliberate overrides. Both exist because an upstream ceiling sits below the patched version, and neither should be removed as cruft:

- **`sharp: ^0.35.0`** — `next` (`^0.34.3`) and `velite` (`^0.34.5`) both cap below the patched 0.35.0.
- **`postcss: ^8.5.18`** — `next` pins `8.4.31` exactly.

Revisit each once upstream widens. The tell that one is needed is two entries for the same package in `yarn.lock`.

Honest scope note: postcss advisories concern parsing untrusted CSS, and postcss runs here at **build time on our own stylesheets**. Practical exposure was close to nil; this is dashboard hygiene plus the lockfile fix, not a live hole being closed.

Both facts are recorded in `docs/learned.md` so the overrides survive future dependency cleanups.
