### PR TITLE
develop

### DIFF
--- a/.claude/skills/blog-hypothesis/SKILL.md
+++ b/.claude/skills/blog-hypothesis/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: blog-hypothesis
+description: Use when a blog post starts as an idea, hunch, opinion, or irritation and no evidence has been gathered yet. Trigger on "I want to write about X", "I have a theory that", "I've been thinking that", "I hate the term", or any post idea arriving without sources.
+---
+
+# State the hypothesis
+
+The first stage. It exists because **research without a falsifiable claim only finds
+confirmation** — you gather what fits and never notice what doesn't.
+
+A hypothesis is not a topic. "Spec-driven development" is a topic. "SDD should be called
+Spec-Driven Delivery because the practice extends past development" is a hypothesis: it can
+be checked, and it can turn out to be wrong.
+
+## Prerequisite
+
+None. This is the entry point.
+
+## Write it to the working doc
+
+One file per post: `docs/research/<slug>.md`, snake_case slug matching the eventual post.
+Create it with the stage block and the hypothesis section:
+
+```markdown
+# <Working title>
+
+## Stage
+
+- [x] Hypothesis
+- [ ] Research
+- [ ] Thesis _(gate — human approval)_
+- [ ] Outline
+- [ ] Draft
+
+## Hypothesis
+
+**Claim.** One sentence, falsifiable.
+
+**Who it's for.** Who changes their mind or their practice if this lands.
+
+**What would falsify it.** The specific finding that would kill or badly wound the claim.
+
+**Why I might be wrong.** The strongest version of the opposing case, written honestly.
+```
+
+## The four fields, and why each is required
+
+| Field     | Purpose                          | Failure if skipped                             |
+| --------- | -------------------------------- | ---------------------------------------------- |
+| Claim     | Gives research something to test | Research becomes topic-browsing                |
+| Audience  | Sets register and depth          | Piece argues with nobody in particular         |
+| Falsifier | Makes the claim honest           | You cannot tell success from confirmation bias |
+| Why wrong | Surfaces the rival case early    | The objection arrives from a reader instead    |
+
+**The falsifier is the one people skip and the one that matters most.** If you cannot name
+a finding that would change your mind, you are not writing an argument — you are writing an
+opinion with citations attached.
+
+## Do not
+
+- **Do not research first and back-fill the hypothesis.** A hypothesis written after the
+  evidence is a summary, and it will quietly match whatever you happened to find.
+- **Do not soften the claim to make it safer.** A hedged claim cannot be falsified, so
+  research cannot inform it. Overstate slightly; the thesis stage will correct it.
+- **Do not skip "why I might be wrong"** because the case seems obvious. On this site's
+  own SDD post, the rival framing (goal-driven development) already existed in public and
+  was found during research, not before it.
+
+## Expect the claim to change
+
+It usually does, and that is the process working rather than failing. The `blog-thesis`
+stage exists specifically to reconcile this hypothesis against what the evidence supported.
+Recording the claim now is what makes that comparison possible later.
+
+## Next step
+
+→ `blog-research` to gather and verify sources against this claim.

--- a/.claude/skills/blog-outline/SKILL.md
+++ b/.claude/skills/blog-outline/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: blog-outline
+description: Use when a post's thesis has been approved and no section order exists yet. Trigger on "outline this", "what order should this go in", "how should this be structured", or before invoking blog-write on a post whose working doc has an approved Thesis but no Outline.
+---
+
+# Order the argument
+
+Turns the settled thesis and the decisions recorded during research into a section order.
+
+## Prerequisite
+
+The working doc `docs/research/<slug>.md` must contain a `## Thesis` section with
+`- [x] Thesis` ticked in the stage block. **An unapproved thesis means no outline** — the
+order of an argument is derived from its claim, so outlining first means ordering evidence
+around a claim that may still move.
+
+## Most of the outline already exists
+
+Ordering constraints accumulate during research and get recorded as decisions. Harvest them
+before inventing structure — on this site's SDD post, the `## Decisions` block already
+specified that the 2004 precedent opens and then steps aside, that the quality argument
+leads over the coverage argument, that the rival framing lands only after the core evidence,
+and that a polysemous term gets defined early. That is four of roughly seven sections,
+already settled and already justified.
+
+Read `## Decisions` first. Invent only what it does not cover.
+
+## Write to the working doc
+
+Append an `## Outline` section. One row per section:
+
+```markdown
+## Outline
+
+**Register.** Essay (~7k chars) or grey paper (~50k, full APA reference list). Decide here —
+it changes section count more than any other choice.
+
+| #   | Section | Claim it makes | Evidence      | Debt  |
+| --- | ------- | -------------- | ------------- | ----- |
+| 1   | ...     | one sentence   | which finding | any ⚠ |
+```
+
+Every section needs a **claim**, not a topic. "Background on SDD" is a topic and will
+produce filler. "The term was borrowed twice, so it was never specified" is a claim and
+produces a paragraph that has to earn its place.
+
+## Checks before handing off
+
+- **Does the order build the thesis sentence?** Read the claims column top to bottom. It
+  should compose into the thesis. If it does not, the order is wrong or a section is filler.
+- **Does the strongest objection get answered?** It was named at the thesis gate. Find the
+  section that handles it. If there is not one, add it.
+- **Is any section carrying a ⚠ that must close before publishing?** Mark it. That is the
+  pre-publication checklist, derived rather than remembered.
+- **Does anything survive that the thesis demoted?** Cut it. Demoted findings reappearing in
+  an outline is how a piece turns back into a list of interesting things.
+
+## Do not
+
+- **Do not outline around the evidence you liked most.** Order follows the argument, not
+  the research effort. A finding that took an hour to verify and supports nothing gets cut.
+- **Do not defer the register decision.** "Decide the length while drafting" produces an
+  essay that grows into a grey paper without the structure of one.
+
+## Next step
+
+→ `blog-write` to draft against this outline.

--- a/.claude/skills/blog-research/SKILL.md
+++ b/.claude/skills/blog-research/SKILL.md
@@ -8,6 +8,18 @@ description: Use when gathering sources for a blog post on this site — runs we
 Produces two things: working notes, and a reference list that can be pasted into a post
 without breaking it.
 
+## Prerequisite
+
+The working doc must contain a `## Hypothesis` section. Check with:
+
+```bash
+yarn stage docs/research/<slug>.md --require research
+```
+
+If it is missing, run `blog-hypothesis` first. **Research without a falsifiable claim finds
+only confirmation** — you gather what fits and never notice what does not. Do not back-fill
+a hypothesis afterwards; one written after the evidence always matches it.
+
 ## Output location
 
 ```
@@ -15,7 +27,7 @@ docs/research/<slug>.md
 ```
 
 Use the same snake_case slug the post will use. This directory is outside `data/`, so
-Velite never ingests it.
+Velite never ingests it. Append to the existing doc — the hypothesis is already there.
 
 ## Gathering
 

--- a/.claude/skills/blog-thesis/SKILL.md
+++ b/.claude/skills/blog-thesis/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: blog-thesis
+description: Use when research on a post is finished and before any outlining or drafting begins. Trigger on "research is done", "ready to write", "let's draft this", or any attempt to invoke blog-outline or blog-write on a post whose working doc has no approved Thesis section.
+---
+
+# Settle the thesis
+
+**This is the human gate.** It is the one mandatory checkpoint in the pipeline, matching the
+Plan gate in `AGENTS.md` — the profile's only required approval.
+
+Its job is to force one question that is otherwise deferred until it is too late:
+**has the claim changed since the hypothesis?**
+
+## Prerequisite
+
+The working doc `docs/research/<slug>.md` must contain a `## Hypothesis` section and a
+`## Findings` section. If either is missing, stop and run `blog-hypothesis` or
+`blog-research` first. Do not reconstruct a hypothesis from the findings — a hypothesis
+written after the evidence always matches it.
+
+## The failure this prevents
+
+Theses drift silently during research, and the drift is invisible because every individual
+step feels small. Left unchecked, the draft argues the original hypothesis while the
+evidence supports something else — and the piece reads as under-argued for reasons the
+author cannot locate.
+
+On this site's SDD post the claim moved from _"SDD extends earlier and later than
+development"_ to _"specs written from the middle are unanchored, and the executable property
+was lost"_ — a materially larger claim, arrived at across three findings, noticed only
+because someone asked.
+
+## Write to the working doc
+
+Append a `## Thesis` section containing all five parts:
+
+```markdown
+## Thesis
+
+**Sentence.** The argument in one sentence. If it needs two, it is not settled.
+
+**Delta from hypothesis.** State explicitly: unchanged, narrowed, widened, or replaced —
+and what moved it. Never omit this line, even when nothing changed.
+
+**Strongest unanswered objection.** The best case against, and whether the piece answers it
+or concedes it. "None" is almost never true.
+
+**Demoted.** Findings that no longer carry weight, and why. Keeping a finding that stopped
+supporting the thesis is how a piece becomes a list.
+
+**Publish gates.** Which ⚠ sourcing items must be closed before publication versus which
+may ship flagged.
+```
+
+## Then stop
+
+**Present the thesis and wait for approval.** Do not continue to `blog-outline` or
+`blog-write` in the same turn. This gate is human-owned; an unapproved thesis is not a
+thesis, and everything downstream inherits it.
+
+Tick `- [x] Thesis` in the stage block only after the human approves.
+
+## Do not
+
+- **Do not skip the delta line when the thesis seems unchanged.** That is exactly when drift
+  hides — it is easier to notice a claim that transformed than one that quietly widened.
+- **Do not write the thesis sentence to match the hypothesis.** The hypothesis was a guess
+  made before evidence. Fidelity to it is not a virtue.
+- **Do not record "no unanswered objection."** If none surfaced during research, the
+  research was too narrow, or the rival position has not been sought. Go find it.
+- **Do not proceed on your own approval.** Presenting the thesis and continuing anyway
+  converts the only gate in the pipeline into a formality.
+
+## Next step
+
+Approved? → `blog-outline`.
+Thesis moved enough to need more evidence? → back to `blog-research`.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "idea": {
+      "url": "http://127.0.0.1:64342/stream",
+      "type": "http"
+    }
+  }
+}

--- a/docs/blog-pipeline.md
+++ b/docs/blog-pipeline.md
@@ -1,0 +1,132 @@
+# Blog pipeline
+
+How the seven `blog-*` skills map onto the Method AI-DLC Lite loop in `AGENTS.md`, and how
+they stay in order.
+
+---
+
+## The mapping
+
+| AIDLC Lite | Skill             | Produces                                    | Gate            |
+| ---------- | ----------------- | ------------------------------------------- | --------------- |
+| **Frame**  | `blog-hypothesis` | Falsifiable claim, audience, falsifier      | —               |
+| **Frame**  | `blog-research`   | Findings, gaps, verified APA references     | —               |
+| **Plan**   | `blog-thesis`     | Thesis sentence, delta, strongest objection | **human owned** |
+| **Plan**   | `blog-outline`    | Section order, register, per-section debt   | —               |
+| **Build**  | `blog-write`      | `data/blog/<year>/<slug>.mdx`               | —               |
+| **Ship**   | `blog-validate`   | Zero errors from `yarn validate`            | —               |
+| **Ship**   | `blog-publish`    | Verified build, commit on `develop`         | **human owned** |
+
+Lite defines exactly one mandatory checkpoint: _"you approve the Plan before Build starts."_
+`blog-thesis` **is** that checkpoint. `blog-publish` adds a second because pushing is
+outward-facing, which is a different kind of irreversibility.
+
+### Why the pipeline gained three stages
+
+It shipped with four skills — research, write, validate, publish — and no equivalent of the
+Plan gate. The gap showed up the first time it ran on a real post:
+
+- **No hypothesis stage.** Research began from a topic rather than a claim, so nothing could
+  be falsified, only supported.
+- **No thesis stage.** The claim moved from _"SDD extends earlier and later than
+  development"_ to _"specs written from the middle are unanchored, and the executable
+  property was lost."_ Materially larger, arrived at over three findings, noticed only
+  because someone asked. `blog-write` would have faithfully drafted the stale one.
+- **No outline stage.** Ordering constraints accumulated during research as ad-hoc decisions
+  with nowhere to live.
+
+The suite skipped the single mandatory checkpoint of the profile it was built under.
+
+---
+
+## Staying in order
+
+**Skills cannot chain themselves.** Nothing in Claude Code invokes the next skill when one
+finishes, so sequence cannot live in the conversation — conversations get resumed, forked,
+and restarted cold.
+
+Order lives in the working doc instead. Three mechanisms, weakest to strongest:
+
+### 1. Each skill names its successor
+
+Every `SKILL.md` ends with a **Next step**. Advisory: it works when an agent is reading
+along and fails silently when one is invoked directly.
+
+### 2. Each skill declares a prerequisite
+
+Every skill past the first opens with **Prerequisite**, naming the H2 section that must
+already exist in the working doc. An agent invoked cold checks the file, not its memory.
+
+### 3. The stage script enforces it
+
+```bash
+yarn stage docs/research/<slug>.md                    # where is this post?
+yarn stage docs/research/<slug>.md --require outline  # exit 1 if blocked
+```
+
+State is derived from the document: an H2 proves a stage produced something, and a ticked
+checkbox in the `## Stage` block proves the gate was approved. Prose alone never counts as
+sign-off — a written-but-unapproved `## Thesis` reports as `AWAITING APPROVAL` and still
+blocks everything downstream.
+
+This is the layer that survives a cold start, and it is checkable rather than remembered.
+
+---
+
+## The working doc
+
+One file per post, `docs/research/<slug>.md`, snake_case slug matching the eventual post.
+Sections accumulate in pipeline order; each skill owns its own and appends rather than
+rewrites.
+
+```markdown
+# <Working title>
+
+## Stage
+
+- [x] Hypothesis
+- [x] Research
+- [ ] Thesis _(gate — human approval)_
+- [ ] Outline
+- [ ] Draft
+
+## Hypothesis <- blog-hypothesis
+
+## Question <- blog-research
+
+## Findings <- blog-research
+
+## Gaps <- blog-research
+
+## Decisions <- accumulates across stages
+
+## Thesis <- blog-thesis
+
+## Outline <- blog-outline
+
+## References <- blog-research
+```
+
+Detected section names are `Hypothesis`, `Findings`, `Thesis`, `Outline` — renaming those
+four breaks stage detection. The rest are conventional.
+
+### Legacy docs
+
+Docs predating the pipeline (`spec_driven_delivery.md`,
+`defense_in_depth_guardrails.md`) have `Findings` but no `Stage` block or `Hypothesis`.
+They report as needing the hypothesis backfilled, which is accurate — the claim was never
+written down before evidence was gathered. Backfilling is optional; nothing forces it.
+
+---
+
+## Running the whole thing
+
+```bash
+yarn stage docs/research/my_post.md    # check position before and after each stage
+yarn validate data/blog/2026/my_post.mdx
+yarn test
+```
+
+The pipeline is deliberately **not** automated end to end. Two of the seven stages are human
+gates, and the value of the middle stages comes from argument rather than throughput — every
+material improvement to the SDD post came from disagreement, not from another pass.

--- a/docs/research/defense_in_depth_guardrails.md
+++ b/docs/research/defense_in_depth_guardrails.md
@@ -1,0 +1,154 @@
+# Research: Defense-in-Depth Guardrails — Four Complementary Layers for LLM Applications
+
+## Question
+
+Does the four-layer guardrail stack (Scan · Classify · Dialog · Structure) hold up as an
+engineering recommendation, and is each layer's "one job" claim supported by primary
+sources rather than vendor marketing?
+
+Secondary question the research had to answer: are the specific tools named in the source
+draft still the right ones to name in August 2026?
+
+## Findings
+
+### The core claim — no single guardrail is sufficient — is well supported
+
+OWASP's 2025 Top 10 for LLM Applications keeps prompt injection at LLM01 for a second
+consecutive edition and explicitly frames mitigation as defense-in-depth: input validation
+_plus_ output filtering _plus_ privilege restriction _plus_ human-in-the-loop for sensitive
+operations. It states that neither RAG nor fine-tuning fully mitigates the class. This is
+the strongest available backing for the article's thesis and should be cited early.
+
+Beurer-Kellner et al. (2025) reach the same conclusion from the design-pattern direction:
+they propose six patterns for prompt-injection resistance rather than one, and explicitly
+trade utility against security per pattern. Strength: strong — 14 authors across ETH Zurich,
+Google, Microsoft, IBM, Invariant Labs.
+
+### The layers map to genuinely distinct, documented failure modes
+
+- **Scan** — LLM Guard ships 15 input scanners and 21 output scanners (README-confirmed
+  list below). The input/output split is real: `Anonymize` on the way in pairs with
+  `Deanonymize` on the way out. Strength: strong (primary README).
+- **Classify** — Inan et al. (2023) built Llama Guard specifically as an _LLM-based_
+  input-output safeguard with a taxonomy, arguing that classification is a different task
+  from scanning. Strength: strong (peer-adjacent, arXiv, Meta).
+- **Dialog** — Rebedea et al. (2023) frame NeMo Guardrails around _conversational_ control
+  (topic routing, dialogue paths), i.e. stateful behavior the stateless I/O scanners have
+  no notion of. Strength: strong (primary paper).
+- **Structure** — Guardrails AI's re-ask mechanism is documented: `OnFailAction.REASK`
+  generates a field-targeted reask prompt, `num_reasks` caps retries, `Guard.for_pydantic()`
+  is the entry point. Strength: strong (primary docs).
+
+### The Llama Guard 1B-vs-8B worked example is corroborated
+
+The draft's anecdote (1B said "violent crime," 8B said "indiscriminate weapons") maps
+exactly onto Meta's published MLCommons taxonomy: **S1 = Violent Crimes**, **S9 =
+Indiscriminate Weapons** (chemical, biological, radiological, nuclear, high-yield
+explosive). The 1B model card also documents the tradeoff that justifies escalation:
+English F1 of **0.899 (1B)** vs **0.939 (8B)**, with Meta itself recommending 8B where
+"better safety classification performance" is wanted "at a higher deployment cost." The
+1B model is trained on 13 categories; 8B on 14 (adds Code Interpreter Abuse for tool-call
+use cases). Strength: strong — the anecdote is now evidence, not just a story.
+
+### Independent benchmarking validates LLM Guard specifically
+
+Palit & Woods (2025) surveyed 13 LLM security solutions (9 proprietary, 4 open source);
+only 7 could be evaluated because proprietary vendors declined to participate. **LLM Guard
+and Lakera Guard "emerged as the best overall tools showcasing the tradeoff between
+usability and performance."** The ChatGPT-3.5-Turbo baseline had "too many false positives
+to be used for this task." Strength: moderate — small study, single dataset, and the
+non-participation of 6 of 13 tools limits the comparison.
+
+### ⚠ MATERIAL CORRECTION TO THE SOURCE DRAFT — LLM Guard is archived
+
+**`protectai/llm-guard` was archived by its owner on July 9, 2026 and is read-only.** The
+repository states the project _and its associated Hugging Face models_ are "no longer under
+active development or maintained." Context: Palo Alto Networks completed its acquisition of
+Protect AI on July 22, 2025 and folded the products into Prisma AIRS; the final release,
+v0.3.16, shipped May 2025.
+
+Verified two ways: the GitHub repository's own archive banner, and independent reporting
+that names the same date and the acquisition. Note that **the project's documentation site
+(`protectai.github.io/llm-guard/`) still describes the project as actively maintained and
+"constantly improving"** — the docs are stale relative to the repo. Anyone evaluating the
+tool from the docs site alone would get the wrong answer.
+
+This does not invalidate the article's architecture — the _Scan layer_ is still the right
+first layer, and an MIT-licensed archived codebase still runs. But the post cannot
+recommend LLM Guard as a live dependency without saying this out loud, and the honest
+framing is: name the layer as durable, name the tool as replaceable. That is arguably a
+_stronger_ article — it demonstrates why the four-layer decomposition matters more than any
+of the four names.
+
+### The false-positive warning in the draft is empirically grounded
+
+Huang et al. (2025) tested 1,123 prompts across three major GenAI platforms. Findings that
+directly support the draft's "shadow mode first" advice:
+
+- False-positive spread was enormous: 13.1% (131 benign prompts blocked) on one platform
+  vs 0.1% on another.
+- The blocked-benign prompts were **disproportionately code review and mathematics
+  questions** — the platform could not distinguish benign code-related keywords from
+  exploits. This is a concrete, citable hazard for any engineering-facing assistant.
+- False negatives ran the other way: one platform's input filters caught only 53% of
+  malicious prompts while others caught 91–92%.
+- Role-play and narrative-framed attacks bypassed filters across _all_ systems.
+
+This is the best single citation for "measure the false-positive rate on real traffic
+before promoting anything to hard-block."
+
+### The NeMo/Colang workaround is a documented path, not a hack
+
+The draft says Colang rails "may not reliably fire" and recommends routing topicality
+through a self-check-input LLM judge instead. `self check input` is a **pre-defined flow**
+in NeMo Guardrails, configured under `rails.input.flows`, with its prompt supplied in
+`prompts.yml`; NVIDIA's docs explicitly describe it as an LLM-as-a-judge technique usable
+with either a separate judge model or the guarded model itself. So the fallback is
+first-class and supported. Strength: strong for _the alternative being supported_; the
+claim that Colang rails misfire is the author's own observation (see Gaps).
+
+## Gaps
+
+- **⚠ The Guardrails AI `click` pin claim is unverified.** The draft states Guardrails AI
+  pins click at or below 8.2.0, conflicting with common data tooling. Searching surfaced no
+  such issue. What _is_ documented is the same _class_ of problem: guardrails-ai 0.5.15+
+  pins `griffe>=0.36.9,<0.37.0`, which conflicts with `openai-agents` requiring
+  `griffe>=1.5.6` (issue #1267), and a fresh-install break when litellm was pulled from
+  PyPI. **Recommendation: keep the argument, swap the example.** Cite griffe, which is
+  documented, rather than click, which is not — or present click as the author's direct
+  observation and flag it as such. Never present it as sourced.
+- **The claim that "most production stacks run two or three of these"** has no source. It is
+  plausible and matches OWASP's layered guidance, but no survey was found that quantifies
+  it. Soften to a claim about recommended practice, or drop the quantifier.
+- **NeMo/Colang misfiring** is first-hand experience, not a documented defect. Present it as
+  such — a field report, explicitly marked.
+- **Fail-open as universal best practice** was not confirmed against a primary security
+  standard. It is defensible engineering and follows from availability requirements, but it
+  is genuinely contested for high-risk surfaces (a fail-open content filter on a
+  child-facing product is a bad default). Present as a considered position with its
+  tradeoff named, not as settled consensus.
+- **Llama Guard 3 model card publication date** is not stated on the card itself. The 1B
+  variant shipped alongside Llama 3.2 (September 2024), but since the card is undated and
+  versioned in-place, it is cited with a retrieval date rather than a publication year.
+
+## References
+
+Beurer-Kellner, L., Buesser, B., Creţu, A.-M., Debenedetti, E., Dobos, D., Fabian, D., Fischer, M., Froelicher, D., Grosse, K., Naeff, D., Ozoani, E., Paverd, A., Tramèr, F., & Volhejn, V. (2025, June 10). Design patterns for securing LLM agents against prompt injections (arXiv:2506.08837). arXiv. https://doi.org/10.48550/arXiv.2506.08837
+
+Guardrails AI. (n.d.). Guards. Guardrails AI documentation. Retrieved August 4, 2026, from https://www.guardrailsai.com/docs/api_reference_markdown/guards
+
+Huang, Y., Bray, N., Rao, A., Ji, Y., & Hu, W. (2025, June 2). How good are the LLM guardrails on the market? A comparative study on the effectiveness of LLM content filtering across major GenAI platforms. Unit 42, Palo Alto Networks. https://unit42.paloaltonetworks.com/comparing-llm-guardrails-across-genai-platforms/
+
+Inan, H., Upasani, K., Chi, J., Rungta, R., Iyer, K., Mao, Y., Tontchev, M., Hu, Q., Fuller, B., Testuggine, D., & Khabsa, M. (2023, December 7). Llama Guard: LLM-based input-output safeguard for human-AI conversations (arXiv:2312.06674). arXiv. https://doi.org/10.48550/arXiv.2312.06674
+
+Meta. (n.d.). Llama Guard 3-1B model card. PurpleLlama. Retrieved August 4, 2026, from https://github.com/meta-llama/PurpleLlama/blob/main/Llama-Guard3/1B/MODEL_CARD.md ⚠ model card is undated and versioned in place; the 1B variant shipped with Llama 3.2 in September 2024, but that date is not stated on the card itself
+
+NVIDIA. (n.d.). Input rails. NeMo Guardrails documentation. Retrieved August 4, 2026, from https://docs.nvidia.com/nemo/guardrails/latest/getting-started/4-input-rails/README.html
+
+OWASP. (2025). OWASP Top 10 for large language model applications 2025. OWASP Foundation. https://owasp.org/www-project-top-10-for-large-language-model-applications/assets/PDF/OWASP-Top-10-for-LLMs-v2025.pdf
+
+Palit, S., & Woods, D. (2025, May 19). Evaluating the efficacy of LLM safety solutions: The Palit benchmark dataset (arXiv:2505.13028). arXiv. https://doi.org/10.48550/arXiv.2505.13028
+
+Protect AI. (2026, July 9). LLM Guard: The security toolkit for LLM interactions [Archived code repository]. GitHub. https://github.com/protectai/llm-guard ⚠ date given is the archival date, not the publication date; repository is read-only as of that date
+
+Rebedea, T., Dinu, R., Sreedhar, M., Parisien, C., & Cohen, J. (2023, October 16). NeMo Guardrails: A toolkit for controllable and safe LLM applications with programmable rails (arXiv:2310.10501). arXiv. https://doi.org/10.48550/arXiv.2310.10501

--- a/docs/research/spec_driven_delivery.md
+++ b/docs/research/spec_driven_delivery.md
@@ -35,38 +35,98 @@ something else. Nobody renamed anything. The word was just picked up again.
 **Evidence:** confirmed against the primary PDF (title page and abstract read directly), not
 a secondary summary.
 
-### 2. Every major SDD tool stops at implementation — this is the core evidence
+### 2. Five tools, five different upstream boundaries, one identical downstream wall
 
-| Tool            | Phases                                                       | Stops at                   |
-| --------------- | ------------------------------------------------------------ | -------------------------- |
-| GitHub Spec Kit | constitution → specify → plan → tasks → implement → converge | code assessed against spec |
-| AWS Kiro        | Requirements → Design → Tasks                                | tasks executed             |
-| Piskala (arXiv) | Specify → Plan → Implement → Validate                        | code matches spec          |
+| Tool            | Phases                                                       | Reaches back to                                              | Stops at              |
+| --------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | --------------------- |
+| AWS Kiro        | Requirements → Design → Tasks                                | requirements                                                 | tasks executed        |
+| Piskala (arXiv) | Specify → Plan → Implement → Validate                        | specification                                                | code matches spec     |
+| OpenSpec        | explore → propose → apply → sync → archive                   | exploration                                                  | change archived       |
+| GitHub Spec Kit | constitution → specify → plan → tasks → implement → converge | org constraints, compliance                                  | code assessed vs spec |
+| BMAD-METHOD     | Analysis → Planning → Solutioning → Implementation           | **brainstorming, research reports, product briefs, PR/FAQs** | code + retrospective  |
 
-Kiro's documentation is explicit: the workflow "does not extend past implementation," with no
-deployment, monitoring, or operational phase. Spec Kit reaches slightly further backward
-(`/speckit.constitution` encodes organizational constraints and compliance; `/speckit.clarify`
-does discovery-ish work) but forward it ends at `converge` — assessing code against the spec.
+**The asymmetry is the finding, not the wall itself.**
 
-**The pattern is consistent and it is exactly the shape of the argument.** The word
-"development" is not an accident of naming; it accurately describes where every one of these
-tools stops. That makes the case _against_ the tools' scope, not merely against their label —
-worth being precise about which claim is being made.
+Upstream, the boundary is porous and clearly moving. Kiro starts at requirements; Spec Kit
+reaches into organizational constraints and compliance; BMAD's Phase 1 produces brainstorms,
+research reports, product briefs, and **PR/FAQs** — the exact Amazon artifact cited in Finding 3
+as the "earlier" evidence. The upstream half of the argument is not contested. It is already
+shipping.
 
-### 3. Specs demonstrably operate earlier than development
+Downstream, the wall is absolute. **Five for five, not one tool covers deployment, monitoring,
+operations, runbooks, or post-release outcome measurement.** OpenSpec's `archive` looked like a
+candidate — it merges delta specs into a primary spec representing "the system's actual state" —
+but the docs place it after implementation and verification and explicitly **before any
+operational work**. BMAD ends with retrospective reviews, which examine the process, not the
+running system.
 
-Amazon's **Working Backwards / PR-FAQ**: a press release and FAQ written _before_ any code,
-explicitly "before writing specifications or defining requirements." It is a specification of
-customer outcome that gates whether engineering is assigned at all. If the press release does
-not excite a customer, the idea is reworked or killed before a single engineer is assigned.
+**This reframes the thesis.** The argument as stated is "earlier _and_ later." The evidence says
+earlier is essentially won and later is universally absent. The sharper piece is about **why the
+boundary is porous in one direction and rigid in the other** — and the answer is in the word.
+"Development" has a natural upstream, because requirements have always been development's
+business. It has no natural downstream: you cannot "develop" a system that is already running.
 
-This is a spec doing its most valuable work _upstream of development entirely_ — the earlier
-extension the argument needs.
+**BMAD also breaks the strongest objection to the thesis.** The counter-argument is that
+"development" accurately describes what these tools do. BMAD does market-adjacent product work —
+briefs, PR/FAQs, UX documents — while still calling itself _Breakthrough Method for Agile AI
+Driven Development_. Here is a tool that has already outgrown the word upstream and kept it
+anyway. That is direct evidence the label no longer tracks the practice, available in the
+present tense rather than as a prediction.
+
+⚠ All five are 2025–26 agentic coding tools. The pattern is strong within that category but it
+is still one category. A non-AI-native counterexample would settle whether this is a fact about
+the word or a fact about a young product segment.
+
+### 3. Working Backwards specifies from the end state — development is the middle, not the origin
+
+Amazon's **Working Backwards / PR-FAQ**: teams "write a press release and FAQ for the thing, as
+if they're launching it today, **before they decide to do it at all**." The method requires
+defining the ideal customer experience first, then developing the product to meet that vision.
+If the press release does not excite a customer, the idea is reworked or killed before a single
+engineer is assigned.
+
+**The direction is the point, and it is easy to file this under the wrong heading.** PR/FAQ is
+not "a spec that happens earlier." The artifact is a description of the **launched, operating
+product as the customer experiences it** — the end state — and the specification is _derived
+backwards from it_. Its origin is downstream of development. Its use is upstream of development.
+Development is the "how" in between, subordinate to both ends.
+
+That reframes Finding 2 considerably. The forward wall is not merely a missing phase at the end
+of a pipeline. **It severs the spec from the thing that generates it.** A practice that stops at
+"code matches spec" has cut off the end state that the spec was supposed to be reasoned back
+from — leaving specification of the middle, by the middle, for the middle.
+
+Incremental delivery does not weaken this. Under Lean Startup and similar models the "end state"
+becomes a milestone or increment rather than a final launch, but the logic is unchanged: you
+specify from the outcome backwards. An MVP is defined by what you intend to learn, not by what
+you intend to build.
+
+**This is a quality argument, not only a scope argument — and that is the stronger claim.** A
+spec derived from a described end state has an anchor: every requirement can be checked against
+"does this produce that press release." A spec written at the development boundary has nothing to
+check against except itself. So SDD-as-development does not merely _cover less_ — it produces
+_worse specs_, because it severed the thing that gives a spec its reference point. That also
+explains the field's standing complaint that specs drift: drift is what happens to a
+specification with no external referent.
+
+Argue this rather than the coverage version wherever both are available. "You are missing a
+phase" invites a shrug. "Your specs are unanchored, and here is why they drift" does not.
+
+⚠ **Tension to resolve, not paper over.** Reasoning backwards from an end state is outcome
+language, which is exactly the ground Yeret occupies with "goal-driven development" (Finding 5).
+The stronger this framing gets, the more it has to answer why the answer is "Delivery" rather
+than "outcome" or "goal."
+
+**Sourcing:** the mechanic is well attested across multiple independent secondary sources and the
+book citation is solid, but ⚠ **the primary text was not read.** Bryar and Carr were both Amazon
+executives (Bryar was Bezos' technical advisor). Verify any direct quotation against the book
+before publishing; the summaries agree on substance but the wording varies between them.
 
 ### 4. Specs demonstrably operate later than development
 
-**Vogels (2006)**, the "you build it, you run it" interview, names the full span in one
-sentence:
+**Vogels, interviewed by Jim Gray (2006)**, names the full span in one sentence. ✅ **Verified**
+— quote confirmed against a full-text mirror of the interview; venue, volume, issue, date and
+DOI all resolved:
 
 > "Each service has a team associated with it, and that team is completely responsible for the
 > service — from scoping out the functionality, to architecting it, to building it, and
@@ -97,20 +157,146 @@ noun but a different one:
 He also reframes specs as an abstraction layer: "the spec is becoming a higher-level
 programming language," "the spec is the work humans maintain."
 
-**This is the most serious competitor to the thesis and the piece is weaker if it ignores it.**
-Yeret keeps "development" and changes "spec"; the argument here keeps "spec" and changes
-"development." They diagnose the same problem — SDD aimed too low — and disagree about which
-word is wrong. Engaging that directly would be the strongest section in the piece.
+**Not a competitor — a different axis, and the two stack.** Yeret's move is _vertical_: specs
+sit at the wrong altitude, climb to goals. The move here is _horizontal_: development is the
+wrong span, extend the boundary. Neither subsumes the other.
 
-### 6. The scope critique is already circulating
+The resolution is a two-layer model, and **"delivery" is the correct noun at both layers**:
 
-Critics argue SDD is too narrowly focused on coding, noting the bottleneck may no longer be
-coding but "review, product judgment, customer access, data quality, adoption, release safety,
-or decision-making." Isoform's "The Limits of Spec-Driven Development" argues static artifacts
-cannot hold the necessary context regardless of precision.
+| Layer         | Artifact | Question it answers | Character                                 |
+| ------------- | -------- | ------------------- | ----------------------------------------- |
+| **Strategic** | Goals    | What outcome, why   | Connects to Working Backwards (Finding 3) |
+| **Tactical**  | Specs    | What is true, now   | Executable ground truth (Finding 7)       |
 
-⚠ These are secondary characterizations from search summaries. **Read the Isoform piece
-directly before citing it** — a claim about someone's argument should come from their text.
+Goal-driven delivery is the strategic effort — it is the same reasoning-from-the-end-state that
+PR/FAQ performs. Spec-driven delivery is the tactical layer beneath it, and its job is
+**ground truth**. Both span product intent through operations. Neither is _development_.
+
+**The move to make is not refutation.** Use Yeret's own premise to force the conclusion: if the
+spec is genuinely "becoming a higher-level programming language" expressing human intent, and
+intent is about outcomes, then the artifact necessarily reaches past code. Intent does not
+terminate at "implementation complete." **Yeret climbed the altitude axis and left the span axis
+untouched, so his conclusion outruns the noun he kept.** He is right, and his argument does not
+stop where he stopped it.
+
+Steelman to survive: _goals imply outcomes, outcomes live past release, so goal-driven implicitly
+solves the span problem._ Answer: no — he kept "development." Naming the aim does not move the
+boundary. Teams with crisp goals still throw code over the wall. The word that sets scope is the
+second word, and he did not touch it.
+
+**Positioning:** one strong section, placed _after_ the five-tool wall and the Amazon bracket
+land. Lead with Yeret and the piece reads as a response post; lead with the evidence and he
+arrives as convergent support.
+
+⚠ I read a summarization of his post, not the full text. **Read it end to end before engaging in
+print** — misrepresenting the one person you are arguing with is the expensive error.
+
+⚠ Open: is "goal-driven development" already an established term with its own literature? If GDD
+has prior art, Yeret is joining a conversation rather than opening one. Not checked.
+
+**Footnote — where the disagreement actually sits.** Yeret and this thesis are saying the same
+thing at different altitudes. He is not wrong about goals; he is **directing attention the wrong
+way**. His corrective pulls focus back up toward strategy, and strategy is not where the deficit
+is. The AI discourse is already saturated with intent, goals, abstraction and framing. What it is
+starving for is the executable, checkable, driven-to-the-ground layer (Finding 7).
+
+So the disagreement is not about whether goals matter. It is about **which direction the field
+currently needs to be pulled** — and the answer is down, toward ground truth, not up toward more
+strategy. That is the argument to make against him: right axis, wrong direction of travel, given
+where the attention already is.
+
+### 6. The critique already circulating attacks specs themselves — not their scope
+
+✅ **Isoform, "The Limits of Spec-Driven Development" (November 25, 2025, author not named)** —
+read directly. Four limits:
+
+1. **Maintenance burden** — specs grow expensive to keep synchronized with code:
+   "documentation debt disguised as engineering discipline."
+2. **Missing context** — specs describe _what_ but not _why_; the assumptions and tradeoffs
+   "only emerge during actual development."
+3. **False confidence** — detailed specs create an "illusion of completeness" that discourages
+   iteration, making development "brittle, waterfall-like."
+4. **Wrong abstraction level** — tools fixate on schemas and field definitions rather than
+   intent, producing "code that is structurally correct but misaligned with the actual intent."
+
+Core claim: **"specs can never capture all the context they need."**
+
+**Three of the four limits are symptoms of this thesis's diagnosis, not counter-evidence.**
+
+- Limit 1 is what happens when a spec is _prose instead of executable_ (Finding 7). Prose drifts
+  silently; an executable spec fails loudly. Adzic's living documentation exists precisely to
+  solve this.
+- Limit 2 is what happens when the spec is _severed from the end state_ (Finding 3). The "why"
+  is the outcome. PR/FAQ captures it because it starts there.
+- Limit 3 is what a spec bounded at development looks like: complete, because it never has to
+  survive contact with operations.
+- Limit 4 is Yeret's altitude point (Finding 5), arriving seven months earlier.
+
+**But the core claim is more radical than the four limits, and it must be answered head-on.**
+"Specs can never capture all the context they need" is an argument against specs _as an
+instrument_, not against their scope. If it holds, widening the boundary yields a wider
+inadequate artifact and the thesis is dead.
+
+**The answer is in the executable framing.** The objection only bites if a spec is supposed to be
+_complete_. An executable spec does not need completeness — it needs to be **checkable**. Tests
+never capture all context either; nobody treats that as an argument against testing. **Ground
+truth is not total truth.** Isoform is refuting an ambition — the spec as exhaustive
+prose description — that the executable tradition never held.
+
+That is also why they are right about current tools and wrong about specs: the 2025 tools _are_
+attempting exhaustive prose, which is exactly the property the term lost after 2011.
+
+**Discourse timeline** — the piece would enter a mature conversation, not open one:
+Spec Kit / Kiro emerge 2025 → Isoform critique Nov 2025 → Yeret reframe June 2026 → this piece.
+
+⚠ The related claim that "the bottleneck may no longer be coding but review, product judgment,
+customer access, data quality, adoption, release safety, or decision-making" came from a **search
+summary with unclear attribution**. Do not attribute it to Isoform or Yeret without tracing it.
+
+### 7. "Executable specification" is the term's lost meaning — and the strongest card in the piece
+
+The tactical layer needs a word for what makes a spec more than prose. That word already exists,
+predates the AI era, and **the 2025 usage quietly dropped it.**
+
+**The lineage runs backwards through every prior meaning of the term:**
+
+- **2004 — Ostroff, Makalsky & Paige** (Finding 1). Their SDD was Design-by-Contract plus TDD:
+  pre/postconditions, class invariants, executable tests. Contracts _run_. Their claim that
+  "both tests and contracts are different types of specifications" is a claim about
+  **executable** artifacts.
+- **2011 — Adzic, _Specification by Example_.** Concrete examples used to "define, validate, and
+  automate requirements as **executable specifications**," producing **living documentation that
+  evolves with the software**. Jolt Award, 2012. Note the subtitle: _How Successful Teams
+  **Deliver** the Right Software_ — the word is already there, in the canonical text on
+  executable specs, fourteen years before this argument.
+- **Formal methods** — VDM-SL and similar have executable subsets; a well-tested executable
+  specification demonstrably benefits implementation. Deep roots, not a novelty.
+
+**And then 2025.** Spec Kit specs are markdown. Kiro's requirements, design and tasks are
+markdown. They are prose an LLM interprets — **not artifacts that run.** The AI-era usage
+inherited the phrase "spec-driven" from traditions where the spec was executable, and made the
+spec _less_ executable than either predecessor.
+
+**This is the sharpest reversal available to the piece.** The complaint is usually that AI SDD is
+too rigid, too waterfall, too much documentation up front. The evidence says the opposite: it is
+too _vague_. It swapped a runnable artifact for a prose one and kept the name.
+
+That is why "executable" carries real weight rather than being a flourish. It names what the
+tactical layer is _for_ — **ground truth, driven to the ground** — against a discourse currently
+heavy on intent, goals, abstraction and vibes, and light on anything that can be run and checked.
+Execution is the missing half of the current AI conversation, and the spec is where it lands.
+
+**It also closes the Finding 2 limitation, partly.** Adzic (2011) is a non-AI-native spec
+practice, and its **living documentation persists past release** — a spec that keeps evolving
+with the running system. So a pre-AI spec practice _did_ reach past the wall the five AI tools
+stop at. The wall is a property of this product generation, not of specs.
+
+⚠ **Sourcing.** Adzic's book details (title, subtitle, publisher, 2011, Jolt Award) are solid
+across multiple sources, but **the primary text was not read**. A search summary also attributed
+to "specification-driven development practice" the goal of "making intent durable — across tools,
+across sessions, and across team members"; that phrasing appears to blend a 2018 Gauge blog post
+with a separate SDD article and **should not be quoted or attributed to anyone** without
+verifying which text it belongs to.
 
 ---
 
@@ -124,12 +310,60 @@ directly before citing it** — a claim about someone's argument should come fro
   returned **HTTP 403**. Worth retrieving another way — it may resolve the date question above.
 - **Ostroff et al. page range unconfirmed.** The DOI and venue are solid; the exact pages in
   LNCS 3092 were not verified. Cite without pages rather than guess.
-- **Vogels interview citation unverified.** The quote is well attested across multiple secondary
-  sources, but ACM Queue returned 403, so volume/issue and the canonical URL are unconfirmed.
+- ~~**Vogels interview citation unverified.**~~ **RESOLVED.** _ACM Queue_ 4(4), June 30 2006,
+  DOI 10.1145/1142055.1142065, interviewed by Jim Gray. queue.acm.org and dl.acm.org both
+  return 403 to automated fetches; confirmed instead against a full-text mirror that preserves
+  the speaker labels ("JG = Jim Gray, WV = Werner Vogels"). Residual ⚠: Semantic Scholar
+  indexes the piece under "O'Hanlon", so ACM's author-of-record may not be Gray even though
+  Gray asks the questions.
 - **Humble & Farley's stated rationale** for "delivery" — see caveat in Finding 4.
 - **No source found that already proposes "Spec-Driven Delivery" by name.** Worth one more
   search before publishing: if someone has proposed it, the piece should credit them; if nobody
   has, that absence is itself worth stating.
+
+---
+
+## Decisions (2026-08-01 review)
+
+Settled while walking the findings. These bind the draft.
+
+- **Finding 1 opens the piece and then steps aside.** High value as structure, low value as
+  evidence — it earns the right to question the term, but a 22-year-old formal-methods paper
+  cannot be load-bearing. One paragraph, not a section. Use the inversion: the term keeps
+  getting recycled _because nobody ever specified what it covers_.
+
+- **Finding 2 is the spine, rebalanced toward the forward wall.** "Earlier and later" treats
+  the two directions symmetrically; the evidence does not. Upstream is essentially won —
+  BMAD already produces PR/FAQs. Downstream is absent in all five tools. The piece argues
+  mainly about the forward wall and uses upstream drift as proof that the boundary moves
+  whenever the word permits it.
+
+- **State the single-category limitation explicitly in the piece.** All five tools are 2025–26
+  agentic coding tools. Five-for-five is strong within one young product category, and no
+  non-AI-native counterexample was found. Say so in the text rather than let a reader find it.
+
+- **Pre-empt "the name is accurate" head-on.** BMAD does brainstorms, research reports,
+  product briefs and PR/FAQs while calling itself _..Agile AI Driven Development_. The label
+  already fails to describe the leading tool — present tense, documented, not a forecast.
+
+- **Lead with the quality argument, not the coverage argument.** The strongest version of the
+  thesis is not "SDD covers too little." It is "specs written from the middle are unanchored,
+  and that is why they drift." Coverage invites a shrug; an unanchored-spec claim does not.
+  Finding 3 supplies this.
+
+- **Define "delivery" early — the word is polysemous in this exact audience.** Engineers hear
+  Humble & Farley's _delivery_, which deliberately stops at deployable (the CD vs. Continuous
+  Deployment line). Consultants and enterprise readers hear _delivery_ as the whole engagement:
+  product intent through realized outcome, operations included. The thesis uses the second
+  sense — product → inception → construction → operations, with development as the "how" in
+  between. Since the entire argument is about where a boundary sits, the piece cannot leave the
+  boundary of its own central noun ambiguous.
+
+  The collision is usable material rather than a liability: _the industry already had a word
+  for the span past development, and then narrowed it to mean deployment automation._
+
+  ⚠ This partly retires the earlier objection that "delivery ends at handoff" — that objection
+  holds against the CD sense only. Finding 4 should be re-read with this distinction in hand.
 
 ---
 
@@ -160,14 +394,24 @@ DOIs pre-encoded. Verified against primary sources except where marked ⚠.
 
 Humble, J., & Farley, D. (2010). _Continuous delivery: Reliable software releases through build, test, and deployment automation._ Addison-Wesley.
 
+Isoform. (2025, November 25). _The limits of spec-driven development._ https://isoform.ai/blog/the-limits-of-spec-driven-development ⚠ no author byline on the piece; cite the organization
+
 Kiro. (n.d.). _Specs._ Kiro documentation. Retrieved August 1, 2026, from https://kiro.dev/docs/specs/
 
 Ostroff, J. S., Makalsky, D., & Paige, R. F. (2004). Agile specification-driven development. In _Extreme Programming and Agile Processes in Software Engineering (XP 2004)_, Lecture Notes in Computer Science, Vol. 3092. Springer. https://doi.org/10.1007/978-3-540-24853-8_12 ⚠ page range not confirmed; title, authors, affiliations and abstract verified against the author's open-access PDF at https://www.eecs.yorku.ca/~jonathan/publications/2004/xp2004.pdf
 
 Piskala, D. B. (2026, January 30). _Spec-driven development: From code to contract in the age of AI coding assistants._ arXiv. https://arxiv.org/abs/2602.00180
 
+Adzic, G. (2011). _Specification by example: How successful teams deliver the right software._ Manning. ⚠ primary text not read; concepts (executable specifications, living documentation) and 2012 Jolt Award attested across multiple sources
+
+BMAD-METHOD. (n.d.). _Workflow map._ BMAD Method documentation. Retrieved August 1, 2026, from https://docs.bmad-method.org/reference/workflow-map/
+
+Bryar, C., & Carr, B. (2021). _Working backwards: Insights, stories, and secrets from inside Amazon._ St. Martin's Press. ⚠ primary text not read; PR/FAQ mechanic attested across multiple independent secondary sources — verify any direct quotation before publishing
+
+OpenSpec. (n.d.). _Workflows._ Fission-AI/OpenSpec. Retrieved August 1, 2026, from https://github.com/Fission-AI/OpenSpec/blob/main/docs/workflows.md
+
 Spec Kit. (n.d.). _GitHub Spec Kit._ GitHub. Retrieved August 1, 2026, from https://github.com/github/spec-kit
 
-Vogels, W., & Gray, J. (2006). A conversation with Werner Vogels. _ACM Queue, 4_(4). ⚠ quote well attested across secondary sources; volume/issue and canonical URL not confirmed — queue.acm.org returned 403
+Gray, J. (2006, June 30). A conversation with Werner Vogels: Learning from the Amazon technology platform. _ACM Queue, 4_(4). https://doi.org/10.1145/1142055.1142065 ⚠ Gray confirmed as interviewer from the interview transcript itself ("JG = Jim Gray, WV = Werner Vogels"); note Semantic Scholar indexes the piece under "O'Hanlon", so ACM's own author-of-record metadata may differ — check the DL listing if the byline matters
 
 Yeret, Y. (2026, June 5). _Is spec-driven development a step forward or back?_ https://yuvalyeret.com/blog/is-spec-driven-development-a-step-forward-or-back-for-product-development/

--- a/docs/research/spec_driven_delivery.md
+++ b/docs/research/spec_driven_delivery.md
@@ -1,0 +1,173 @@
+# Research: Spec-Driven Delivery
+
+## Question
+
+Does the argument hold that **SDD should mean Spec-Driven _Delivery_, not Spec-Driven
+_Development_** — because the practice extends both earlier (discovery, product definition)
+and later (release, operations, outcomes) than the development phase?
+
+Verdict from the sources: **yes, and the evidence is stronger than expected.** Every major
+SDD tool and the one serious academic treatment all stop at or before "implementation is
+done." Meanwhile the two most durable spec practices in the industry — Amazon's PR/FAQ and
+"you build it, you run it" — sit on either side of that boundary. The gap the argument
+names is real and documented.
+
+---
+
+## Findings
+
+### 1. The term is young, contested, and already recycled — twice
+
+**The 2004 meaning was different, and already abbreviated SDD.** Ostroff, Makalsky, and
+Paige presented "Agile Specification-Driven Development" at XP 2004. Their abstract:
+
+> "We present an agile approach to Specification-Driven Development, which combines features
+> of Test-Driven Development and the plan-based approach of Design-by-Contract. We argue that
+> both tests and contracts are different types of specifications."
+
+Their scope was **narrower than today's** — pre/postconditions and class invariants in Eiffel,
+purely code-level correctness. They used the initialism "SDD" in the paper.
+
+This is the strongest available hook for a piece about the term: the 2025 AI-coding usage
+recycled both the phrase _and_ the acronym from a 2004 formal-methods paper that meant
+something else. Nobody renamed anything. The word was just picked up again.
+
+**Evidence:** confirmed against the primary PDF (title page and abstract read directly), not
+a secondary summary.
+
+### 2. Every major SDD tool stops at implementation — this is the core evidence
+
+| Tool            | Phases                                                       | Stops at                   |
+| --------------- | ------------------------------------------------------------ | -------------------------- |
+| GitHub Spec Kit | constitution → specify → plan → tasks → implement → converge | code assessed against spec |
+| AWS Kiro        | Requirements → Design → Tasks                                | tasks executed             |
+| Piskala (arXiv) | Specify → Plan → Implement → Validate                        | code matches spec          |
+
+Kiro's documentation is explicit: the workflow "does not extend past implementation," with no
+deployment, monitoring, or operational phase. Spec Kit reaches slightly further backward
+(`/speckit.constitution` encodes organizational constraints and compliance; `/speckit.clarify`
+does discovery-ish work) but forward it ends at `converge` — assessing code against the spec.
+
+**The pattern is consistent and it is exactly the shape of the argument.** The word
+"development" is not an accident of naming; it accurately describes where every one of these
+tools stops. That makes the case _against_ the tools' scope, not merely against their label —
+worth being precise about which claim is being made.
+
+### 3. Specs demonstrably operate earlier than development
+
+Amazon's **Working Backwards / PR-FAQ**: a press release and FAQ written _before_ any code,
+explicitly "before writing specifications or defining requirements." It is a specification of
+customer outcome that gates whether engineering is assigned at all. If the press release does
+not excite a customer, the idea is reworked or killed before a single engineer is assigned.
+
+This is a spec doing its most valuable work _upstream of development entirely_ — the earlier
+extension the argument needs.
+
+### 4. Specs demonstrably operate later than development
+
+**Vogels (2006)**, the "you build it, you run it" interview, names the full span in one
+sentence:
+
+> "Each service has a team associated with it, and that team is completely responsible for the
+> service — from scoping out the functionality, to architecting it, to building it, and
+> operating it."
+
+Note the span: _scoping → architecting → building → operating_. "Development" covers the
+middle two. This quote is close to a ready-made spine for the article.
+
+**Humble & Farley (2010)** made the same move at the level of naming: the book is _Continuous
+Delivery_, not _Continuous Development_, and its subtitle extends explicitly through "Build,
+Test, and Deployment Automation." The industry has already once chosen "delivery" over
+"development" to signal a wider boundary — a direct precedent for the argument.
+
+⚠ **Caveat:** I could not find Humble and Farley stating their terminological reasoning
+explicitly. The book demonstrably covers the wider scope; whether they chose the word
+"delivery" _for that reason_ is an inference. Present it as precedent, not as their stated
+intent, or verify against the book's introduction.
+
+### 5. A rival reframing already exists and must be engaged
+
+**Yeret (2026, June 5)** argues the narrow reading of SDD is a misunderstanding — "requirements
+theater," specs as handoff paperwork, "the wrong mental model." His alternative is not a wider
+noun but a different one:
+
+> "the way to shift AI activity to impact goes one step further beyond spec-driven development
+> towards **goal-driven development**"
+
+He also reframes specs as an abstraction layer: "the spec is becoming a higher-level
+programming language," "the spec is the work humans maintain."
+
+**This is the most serious competitor to the thesis and the piece is weaker if it ignores it.**
+Yeret keeps "development" and changes "spec"; the argument here keeps "spec" and changes
+"development." They diagnose the same problem — SDD aimed too low — and disagree about which
+word is wrong. Engaging that directly would be the strongest section in the piece.
+
+### 6. The scope critique is already circulating
+
+Critics argue SDD is too narrowly focused on coding, noting the bottleneck may no longer be
+coding but "review, product judgment, customer access, data quality, adoption, release safety,
+or decision-making." Isoform's "The Limits of Spec-Driven Development" argues static artifacts
+cannot hold the necessary context regardless of precision.
+
+⚠ These are secondary characterizations from search summaries. **Read the Isoform piece
+directly before citing it** — a claim about someone's argument should come from their text.
+
+---
+
+## Gaps
+
+- **Spec Kit's release date is unresolved.** One secondary source says September 2024; the same
+  source frames SDD as emerging in 2025, which is inconsistent. The GitHub repo does not state a
+  founding date in its README. Resolve via the repository's release tags or first commit before
+  making any claim about when SDD started.
+- **`specdriven.com/origins`** looked directly on-topic (a page about the term's coinage) but
+  returned **HTTP 403**. Worth retrieving another way — it may resolve the date question above.
+- **Ostroff et al. page range unconfirmed.** The DOI and venue are solid; the exact pages in
+  LNCS 3092 were not verified. Cite without pages rather than guess.
+- **Vogels interview citation unverified.** The quote is well attested across multiple secondary
+  sources, but ACM Queue returned 403, so volume/issue and the canonical URL are unconfirmed.
+- **Humble & Farley's stated rationale** for "delivery" — see caveat in Finding 4.
+- **No source found that already proposes "Spec-Driven Delivery" by name.** Worth one more
+  search before publishing: if someone has proposed it, the piece should credit them; if nobody
+  has, that absence is itself worth stating.
+
+---
+
+## Angle notes
+
+The strongest structure the evidence supports:
+
+1. **The term was borrowed twice** (2004 formal methods → 2025 AI coding), so treating it as
+   settled vocabulary is a mistake to begin with.
+2. **The tools prove the charge.** Three independent implementations, all stopping at
+   implementation. This is documented, not asserted.
+3. **Both extensions already exist in practice** — PR/FAQ upstream, "you build it, you run it"
+   downstream — so "delivery" is not a coinage, it is a description of what mature teams already
+   do with specs.
+4. **The industry already made this exact swap once**, with Continuous Delivery.
+5. **Answer Yeret**: is the wrong word "spec" or "development"? Arguably both fail differently —
+   "goal-driven" solves the _aim_ problem while leaving the _span_ problem untouched.
+
+This maps onto the four-phase lifecycle already in use in the Method AI-DLC material
+(pre-inception → inception → construction → operations): every SDD tool surveyed lives entirely
+inside _construction_. That framing is available and owned, though the piece works without it.
+
+---
+
+## References
+
+DOIs pre-encoded. Verified against primary sources except where marked ⚠.
+
+Humble, J., & Farley, D. (2010). _Continuous delivery: Reliable software releases through build, test, and deployment automation._ Addison-Wesley.
+
+Kiro. (n.d.). _Specs._ Kiro documentation. Retrieved August 1, 2026, from https://kiro.dev/docs/specs/
+
+Ostroff, J. S., Makalsky, D., & Paige, R. F. (2004). Agile specification-driven development. In _Extreme Programming and Agile Processes in Software Engineering (XP 2004)_, Lecture Notes in Computer Science, Vol. 3092. Springer. https://doi.org/10.1007/978-3-540-24853-8_12 ⚠ page range not confirmed; title, authors, affiliations and abstract verified against the author's open-access PDF at https://www.eecs.yorku.ca/~jonathan/publications/2004/xp2004.pdf
+
+Piskala, D. B. (2026, January 30). _Spec-driven development: From code to contract in the age of AI coding assistants._ arXiv. https://arxiv.org/abs/2602.00180
+
+Spec Kit. (n.d.). _GitHub Spec Kit._ GitHub. Retrieved August 1, 2026, from https://github.com/github/spec-kit
+
+Vogels, W., & Gray, J. (2006). A conversation with Werner Vogels. _ACM Queue, 4_(4). ⚠ quote well attested across secondary sources; volume/issue and canonical URL not confirmed — queue.acm.org returned 403
+
+Yeret, Y. (2026, June 5). _Is spec-driven development a step forward or back?_ https://yuvalyeret.com/blog/is-spec-driven-development-a-step-forward-or-back-for-product-development/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "cross-env INIT_CWD=$PWD next build && cross-env NODE_OPTIONS='--experimental-json-modules' node ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
+    "stage": "node scripts/blog-stage.mjs",
     "validate": "node scripts/validate-post.mjs",
     "validate:all": "node scripts/validate-post.mjs data/blog/*/*.mdx",
     "test": "node --test 'scripts/*.test.mjs'",

--- a/scripts/blog-stage.mjs
+++ b/scripts/blog-stage.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Report — and enforce — where a post sits in the blog pipeline.
+ *
+ * Skills cannot chain themselves: nothing in Claude Code invokes the next skill when one
+ * finishes. Order therefore cannot live in the conversation, because a conversation can be
+ * resumed, forked, or restarted from cold. It lives in the working doc instead, and this
+ * script reads it.
+ *
+ * The doc is the ground truth for pipeline position, which is the same argument the
+ * pipeline exists to make about specs.
+ *
+ * Usage:
+ *   node scripts/blog-stage.mjs docs/research/my_post.md
+ *   node scripts/blog-stage.mjs docs/research/my_post.md --require thesis
+ *
+ * With --require <stage>, exits non-zero if that stage's prerequisites are unmet.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * The pipeline, in order.
+ *
+ * `section` is the H2 whose presence proves the stage produced something. `gated` marks a
+ * stage that additionally needs a ticked checkbox in the Stage block — human approval,
+ * which the presence of prose cannot demonstrate.
+ */
+export const STAGES = [
+  { name: 'hypothesis', section: 'Hypothesis', skill: 'blog-hypothesis', gated: false },
+  { name: 'research', section: 'Findings', skill: 'blog-research', gated: false },
+  { name: 'thesis', section: 'Thesis', skill: 'blog-thesis', gated: true },
+  { name: 'outline', section: 'Outline', skill: 'blog-outline', gated: false },
+  { name: 'draft', section: null, skill: 'blog-write', gated: false },
+]
+
+/** H2 headings present in the doc, lowercased. */
+export function headings(raw) {
+  return raw
+    .split('\n')
+    .filter((line) => /^##\s+/.test(line))
+    .map((line) => line.replace(/^##\s+/, '').trim().toLowerCase())
+}
+
+/**
+ * Checkbox states from the Stage block, e.g. `- [x] Thesis` -> { thesis: true }.
+ *
+ * Trailing annotations are tolerated: `- [ ] Thesis _(gate — human approval)_` still keys
+ * on "thesis", so the template can explain itself without breaking the parse.
+ */
+export function checkboxes(raw) {
+  const found = {}
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*-\s*\[([ xX])\]\s*([A-Za-z][A-Za-z ]*?)(?:\s*[_(].*)?$/)
+    if (m) found[m[2].trim().toLowerCase()] = m[1].toLowerCase() === 'x'
+  }
+  return found
+}
+
+/**
+ * Evaluate every stage against the doc.
+ *
+ * A stage is `done` when its section exists and, if gated, its box is ticked. `current` is
+ * the first stage that is not done — the one to run next.
+ */
+export function evaluate(raw) {
+  const present = new Set(headings(raw))
+  const ticks = checkboxes(raw)
+
+  const stages = STAGES.map((stage) => {
+    const hasSection = stage.section ? present.has(stage.section.toLowerCase()) : false
+    const approved = stage.gated ? ticks[stage.name] === true : true
+    return {
+      ...stage,
+      hasSection,
+      approved,
+      done: hasSection && approved,
+      // A gated stage that wrote its section but was never approved is the interesting
+      // failure: work happened, sign-off did not.
+      awaitingApproval: stage.gated && hasSection && !approved,
+    }
+  })
+
+  return { stages, current: stages.find((s) => !s.done) ?? null }
+}
+
+/** Prerequisites for a stage are every stage before it. */
+export function blockers(raw, target) {
+  const idx = STAGES.findIndex((s) => s.name === target)
+  if (idx === -1) return { unknown: true, missing: [] }
+  const { stages } = evaluate(raw)
+  return { unknown: false, missing: stages.slice(0, idx).filter((s) => !s.done) }
+}
+
+// ---- CLI -----------------------------------------------------------------------
+
+function main(argv) {
+  const args = argv.filter((a) => !a.startsWith('--'))
+  const requireIdx = argv.indexOf('--require')
+  const required = requireIdx !== -1 ? argv[requireIdx + 1] : null
+  const file = args[0]
+
+  if (!file) {
+    console.error('Usage: node scripts/blog-stage.mjs <working-doc.md> [--require <stage>]')
+    return 2
+  }
+
+  let raw
+  try {
+    raw = fs.readFileSync(file, 'utf8')
+  } catch {
+    console.error(`  ✗ cannot read ${file}`)
+    return 2
+  }
+
+  const { stages, current } = evaluate(raw)
+
+  console.log(`\n  ${path.basename(file)}\n`)
+  for (const s of stages) {
+    const mark = s.done ? '✓' : s.awaitingApproval ? '!' : '·'
+    const note = s.awaitingApproval
+      ? '  written, AWAITING APPROVAL'
+      : s.done
+        ? ''
+        : `  ← run ${s.skill}`
+    console.log(`    ${mark} ${s.name.padEnd(11)}${note}`)
+  }
+
+  console.log(
+    current
+      ? `\n  next: ${current.skill}${current.awaitingApproval ? ' (needs human approval, not more writing)' : ''}\n`
+      : '\n  pipeline complete through outline\n'
+  )
+
+  if (required) {
+    const { unknown, missing } = blockers(raw, required)
+    if (unknown) {
+      console.error(`  ✗ unknown stage "${required}"`)
+      return 2
+    }
+    if (missing.length) {
+      console.error(`  ✗ ${required} is blocked by: ${missing.map((s) => s.name).join(', ')}`)
+      console.error(`    run ${missing[0].skill} first\n`)
+      return 1
+    }
+    console.log(`  ✓ ${required} is unblocked\n`)
+  }
+
+  return 0
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)
+) {
+  process.exit(main(process.argv.slice(2)))
+}

--- a/scripts/blog-stage.mjs
+++ b/scripts/blog-stage.mjs
@@ -36,7 +36,7 @@ export const STAGES = [
 ]
 
 /** H2 headings present in the doc, lowercased. */
-export function headings(raw) {
+export const headings = (raw) => {
   return raw
     .split('\n')
     .filter((line) => /^##\s+/.test(line))

--- a/scripts/blog-stage.test.mjs
+++ b/scripts/blog-stage.test.mjs
@@ -1,0 +1,144 @@
+/**
+ * Tests for scripts/blog-stage.mjs
+ *
+ * The case that matters most is the gated stage: a Thesis section can exist while approval
+ * has not happened. If the script treated written prose as sign-off, the one human gate in
+ * the pipeline would enforce nothing.
+ */
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { evaluate, blockers, headings, checkboxes, STAGES } from './blog-stage.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const doc = (sections, stageBlock = '') => `# Post\n\n${stageBlock}\n${sections.join('\n\n')}\n`
+const section = (name) => `## ${name}\n\nbody text`
+
+const stageBlock = (ticked = []) =>
+  '## Stage\n\n' +
+  STAGES.map((s) => {
+    const label = s.name[0].toUpperCase() + s.name.slice(1)
+    const gate = s.gated ? ' _(gate — human approval)_' : ''
+    return `- [${ticked.includes(s.name) ? 'x' : ' '}] ${label}${gate}`
+  }).join('\n')
+
+describe('parsing', () => {
+  test('reads H2 headings only', () => {
+    const raw = '# Title\n## Hypothesis\n### Sub\n## Findings\n'
+    assert.deepEqual(headings(raw), ['hypothesis', 'findings'])
+  })
+
+  test('reads checkbox state', () => {
+    const raw = '- [x] Hypothesis\n- [ ] Thesis\n'
+    assert.deepEqual(checkboxes(raw), { hypothesis: true, thesis: false })
+  })
+
+  test('tolerates trailing annotations on a checkbox label', () => {
+    // The template annotates the gate; the parser must still key on the stage name.
+    const raw = '- [ ] Thesis _(gate — human approval)_\n'
+    assert.equal(checkboxes(raw).thesis, false)
+  })
+})
+
+describe('stage evaluation', () => {
+  test('an empty doc starts at hypothesis', () => {
+    const { current } = evaluate(doc([]))
+    assert.equal(current.name, 'hypothesis')
+    assert.equal(current.skill, 'blog-hypothesis')
+  })
+
+  test('hypothesis alone advances to research', () => {
+    const { current } = evaluate(doc([section('Hypothesis')], stageBlock(['hypothesis'])))
+    assert.equal(current.name, 'research')
+  })
+
+  test('findings advance to thesis', () => {
+    const raw = doc([section('Hypothesis'), section('Findings')], stageBlock(['hypothesis']))
+    assert.equal(evaluate(raw).current.name, 'thesis')
+  })
+})
+
+describe('the thesis gate', () => {
+  const written = doc(
+    [section('Hypothesis'), section('Findings'), section('Thesis')],
+    stageBlock(['hypothesis'])
+  )
+
+  test('a written but unapproved thesis does not count as done', () => {
+    const thesis = evaluate(written).stages.find((s) => s.name === 'thesis')
+
+    assert.equal(thesis.hasSection, true, 'section was written')
+    assert.equal(thesis.approved, false, 'but never approved')
+    assert.equal(thesis.done, false, 'so the stage is not complete')
+    assert.equal(thesis.awaitingApproval, true)
+  })
+
+  test('an unapproved thesis blocks the outline', () => {
+    const { missing } = blockers(written, 'outline')
+    assert.deepEqual(
+      missing.map((s) => s.name),
+      ['thesis']
+    )
+  })
+
+  test('ticking the box releases the gate', () => {
+    const approved = doc(
+      [section('Hypothesis'), section('Findings'), section('Thesis')],
+      stageBlock(['hypothesis', 'thesis'])
+    )
+
+    assert.equal(evaluate(approved).current.name, 'outline')
+    assert.deepEqual(blockers(approved, 'outline').missing, [])
+  })
+})
+
+describe('blockers', () => {
+  test('names every unmet prerequisite, earliest first', () => {
+    const { missing } = blockers(doc([]), 'outline')
+    assert.deepEqual(
+      missing.map((s) => s.name),
+      ['hypothesis', 'research', 'thesis']
+    )
+  })
+
+  test('reports an unknown stage rather than passing it', () => {
+    assert.equal(blockers(doc([]), 'nonsense').unknown, true)
+  })
+
+  test('a fully staged doc blocks nothing', () => {
+    const raw = doc(
+      [section('Hypothesis'), section('Findings'), section('Thesis'), section('Outline')],
+      stageBlock(['hypothesis', 'thesis'])
+    )
+    assert.deepEqual(blockers(raw, 'draft').missing, [])
+  })
+})
+
+describe('real working docs', () => {
+  // Both predate the pipeline. They must degrade gracefully rather than throw — a legacy
+  // doc should be reported as mid-pipeline, not treated as corrupt.
+  const legacy = fs
+    .readdirSync(path.join(repoRoot, 'docs', 'research'))
+    .filter((f) => f.endsWith('.md'))
+
+  test('finds the existing research docs', () => {
+    assert.ok(legacy.length >= 1, 'expected at least one working doc')
+  })
+
+  for (const file of legacy) {
+    test(`${file} evaluates without throwing`, () => {
+      const raw = fs.readFileSync(path.join(repoRoot, 'docs', 'research', file), 'utf8')
+      const { stages, current } = evaluate(raw)
+
+      assert.equal(stages.length, STAGES.length)
+      // Pre-pipeline docs have Findings but no Hypothesis section, so they report as
+      // needing the hypothesis backfilled — correct, and better than silently passing.
+      assert.ok(current === null || typeof current.skill === 'string')
+    })
+  }
+})

--- a/scripts/blog-stage.test.mjs
+++ b/scripts/blog-stage.test.mjs
@@ -16,11 +16,19 @@ import { evaluate, blockers, headings, checkboxes, STAGES } from './blog-stage.m
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-const doc = (sections, stageBlock = '') => `# Post\n\n${stageBlock}\n${sections.join('\n\n')}\n`
-const section = (name) => `## ${name}\n\nbody text`
+const doc = (sections, stageBlock = '') => `# Post
+
+${stageBlock}
+${sections.join('\n\n')}
+`
+const section = (name) => `## ${name}
+
+body text`
 
 const stageBlock = (ticked = []) =>
-  '## Stage\n\n' +
+  '## Stage
+
+' +
   STAGES.map((s) => {
     const label = s.name[0].toUpperCase() + s.name.slice(1)
     const gate = s.gated ? ' _(gate — human approval)_' : ''


### PR DESCRIPTION
## What & why

<!-- What does this change do, and why? Link the roadmap item / Linear issue (e.g. EMA-xx, Bxx). -->

## How it was validated

<!-- Commands run, what you checked, what you actually saw. One step at a time. -->

## Notes

<!-- Gotchas, follow-ups, or anything a reviewer (or future-you) should know. -->

## Summary by Sourcery

Introduce a structured blog-writing pipeline with enforceable stages and human gates, and add supporting scripts, docs, and research artifacts.

New Features:
- Add a blog staging CLI script to infer and enforce a post's pipeline stage from its working document and gate progression to later stages.
- Define new Claude skills for hypothesis, thesis, and outline stages to formalize the early phases of blog post creation.
- Document the end-to-end blog pipeline and how skills map onto the Method AI-DLC Lite loop.
- Add new research working documents for spec-driven delivery and defense-in-depth guardrails to support upcoming blog posts.

Enhancements:
- Tighten the blog research skill docs to require a prior hypothesis and append to the existing working document instead of overwriting.
- Extend package scripts with a reusable `stage` command for checking and enforcing blog pipeline stages.

Tests:
- Add unit tests for the blog staging script, including behavior for gated stages and legacy research docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a guided seven-stage blog creation pipeline covering hypothesis, research, thesis, outline, and drafting.
  - Added stage detection, prerequisite checks, progress reporting, and human approval gates.
  - Added an idea service connection for supported workflows.

- **Documentation**
  - Added guidance for running and validating the blog pipeline.
  - Added research documents on defense-in-depth guardrails and Spec-Driven Delivery.
  - Documented working-document structure, evidence requirements, objections, and legacy-file handling.

- **Tests**
  - Added coverage for stage progression, approvals, blockers, and legacy documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->